### PR TITLE
fix: Value of '-3' is not valid for 'alpha'.

### DIFF
--- a/nQuant.Core/PaletteColorHistory.cs
+++ b/nQuant.Core/PaletteColorHistory.cs
@@ -4,11 +4,11 @@ namespace nQuant
 {
     struct PaletteColorHistory
     {
-        public int Alpha;
-        public int Red;
-        public int Green;
-        public int Blue;
-        public int Sum;
+        public ulong Alpha;
+        public ulong Red;
+        public ulong Green;
+        public ulong Blue;
+        public ulong Sum;
 
         public Color ToNormalizedColor()
         {


### PR DESCRIPTION
When dealing with large files, there is possibility that if there are too many pixels with the same colour, it will wrap the int.
This is particularly likely with the Alpha value because a non-transparent image will have values of 255 for each pixel.

This changed the variables in the PaletteColorHistory to be ulong which also mitigates the error by not allowing negative values (if it wraps, it would be > 0 still).